### PR TITLE
add appNotificationSettings()

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,7 @@ AndroidOpenSettings.applicationSettings()
 
 // Open device info settings menu
 AndroidOpenSettings.deviceInfoSettings()
+
+// Open application notification settings menu
+AndroidOpenSettings.appNotificationSettings()
 ```

--- a/android/src/main/java/com/levelasquez/androidopensettings/AndroidOpenSettings.java
+++ b/android/src/main/java/com/levelasquez/androidopensettings/AndroidOpenSettings.java
@@ -213,4 +213,22 @@ public class AndroidOpenSettings extends ReactContextBaseJavaModule {
             reactContext.startActivity(intent);
         }
     }
+
+    @ReactMethod
+    public void appNotificationSettings() {
+        Intent intent = new Intent("android.settings.APP_NOTIFICATION_SETTINGS"); // Settings.ACTION_APP_NOTIFICATION_SETTINGS
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+
+        //for Android 5-7
+        intent.putExtra("app_package", reactContext.getPackageName());
+        intent.putExtra("app_uid", reactContext.getApplicationInfo().uid);
+
+        // for Android 8 and above
+        intent.putExtra("android.provider.extra.APP_PACKAGE", reactContext.getPackageName()); // Settings.EXTRA_APP_PACKAGE
+
+        if (intent.resolveActivity(reactContext.getPackageManager()) != null) {
+            reactContext.startActivity(intent);
+        }
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,4 +18,5 @@ declare module "react-native-android-open-settings" {
   const accessibilitySettings: () => void;
   const applicationSettings: () => void;
   const deviceInfoSettings: () => void;
+  const appNotificationSettings: () => void;
 }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ const applicationSettings = () => RNAndroidOpenSettings.applicationSettings()
 
 const deviceInfoSettings = () => RNAndroidOpenSettings.deviceInfoSettings()
 
+const appNotificationSettings = () => RNAndroidOpenSettings.appNotificationSettings()
+
 module.exports = {
   generalSettings,
   homeSettings,
@@ -60,4 +62,5 @@ module.exports = {
   accessibilitySettings,
   applicationSettings,
   deviceInfoSettings,
+  appNotificationSettings,
 }


### PR DESCRIPTION
This PR adds appNotificationSettings() method to open the intent [ACTION_APP_NOTIFICATION_SETTINGS](https://developer.android.com/reference/android/provider/Settings.html#ACTION_APP_NOTIFICATION_SETTINGS).

The code comes from https://stackoverflow.com/questions/32366649/any-way-to-link-to-the-android-notification-settings-for-my-app

It is written using hard coded Strings instead of `Settings` fields so it can be compiled with older SDKs.
