### PR TITLE
Add add promise helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,12 @@ AndroidOpenSettings.deviceInfoSettings()
 
 // Open application notification settings menu
 AndroidOpenSettings.appNotificationSettings()
+
+// Calls the passed in settings function and then
+// returns a promise that resolves after they're back
+AndroidOpenSettings.openAsPromised(
+    AndroidOpenSettings.appNotificationSettings
+).then(() => {
+    // back from settings, do stuff!
+});
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,4 +19,5 @@ declare module "react-native-android-open-settings" {
   const applicationSettings: () => void;
   const deviceInfoSettings: () => void;
   const appNotificationSettings: () => void;
+  const openAsPromised: (settingFunc: () => void) => Promise<void>;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native'
+import { NativeModules, AppState } from 'react-native'
 
 const { RNAndroidOpenSettings } = NativeModules
 
@@ -42,6 +42,25 @@ const deviceInfoSettings = () => RNAndroidOpenSettings.deviceInfoSettings()
 
 const appNotificationSettings = () => RNAndroidOpenSettings.appNotificationSettings()
 
+const openAsPromised = (settingFunc)  => {
+  return new Promise((resolve, reject) => {
+    const listener = (state) => {
+      if (state === 'active') {
+        AppState.removeEventListener('change', listener)
+        resolve()
+      }
+    };
+    AppState.addEventListener('change', listener)
+    try {
+      settingFunc()
+    }
+    catch (e) {
+      AppState.removeEventListener('change', listener)
+      reject(e)
+    }
+  });
+}
+
 module.exports = {
   generalSettings,
   homeSettings,
@@ -63,4 +82,5 @@ module.exports = {
   applicationSettings,
   deviceInfoSettings,
   appNotificationSettings,
+  openAsPromised
 }


### PR DESCRIPTION
Adds helper function 'openAsPromised', to enable running code after they return from settings. Leaves everything else untouched.  Was kinda wondering about a Java implementation, but doing it with AppState seems to work just fine.

Resolves https://github.com/levelasquez/react-native-android-open-settings/issues/8